### PR TITLE
Remove Apache2 PID file left after a power loss

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -49,4 +49,10 @@ mysql -h mysql -u known -p$KNOWN_MYSQL_PASSWORD known \
     < /var/www/known/schemas/mysql/mysql.sql
 
 source /etc/apache2/envvars
+
+if [ -f "$APACHE_PID_FILE" ]; then
+    echo "$me: warning: removing existing Apache PID file: $APACHE_PID_FILE"
+    rm -f "$APACHE_PID_FILE"
+fi
+
 exec "$@"


### PR DESCRIPTION
Apache2 will not start when the apache2.pid file still exists:

    httpd (pid 1) already running

This happens after a non-clean shutdown. To reproduce execute:

    docker kill $CID
    docker start $CID
    docker logs $CID

This commit modifies the startup script to remove that file.
A diagnostics message is written to stdout if the file existed.

Note the workaround is to immediately try to remove it after starting the container:

    docker start $CID; docker exec $CID rm /run/apache2/apache2.pid

See also [How to remove a stale PID from a Docker container](http://peterfisher.me.uk/server-side/docker/how-to-remove-a-stale-pid-from-a-docker-container/)